### PR TITLE
Calendar component's 'eventArray' prop default value as a factory function

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -145,7 +145,7 @@
       },
       eventArray: {
         type: Array,
-        default: []
+        default: () => []
       },
       eventRef: {
         type: String,


### PR DESCRIPTION
This commit makes the `eventArray` ptop default value of the `Calendar` component a factory function instead of an array literal as required by Vue