### PR TITLE
Calendar month day click

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,21 @@ Only a subset of fields are currently editable:
 * Summary / title
 * Description
 
+## Calendar Month Day Click Events
+
+The `CalendarMonth` component triggers a "click-day-{eventRef}" event when a calendar cell is clicked. The event data is an object describing the day, with a `day`, `month`, and `year` property each set to the appropriate value for the selected day.
+
+So for a `<calendar-month>` component with a "MYCALENDAR" `event-ref`:
+```js
+this.$root.$on(
+  'click-day-MYCALENDAR',
+  function (day) {
+    // do something here
+  }
+)
+```
+
+
 ## Individual Vue components
 
 The usable components of `Calendar`, `CalendarMonth`, `CalendarMultiDay` and `CalendarAgenda` share the following properties:

--- a/src/components/calendar/CalendarMonth.vue
+++ b/src/components/calendar/CalendarMonth.vue
@@ -39,6 +39,7 @@
           }"
           v-for="(thisDay, weekDayIndex) in thisWeek"
           :key="makeDT(thisDay.dateObject).toISODate()"
+          @click="handleDayClick(thisDay.dateObject)"
         >
           <div
             v-if="isCurrentDate(thisDay.dateObject)"
@@ -46,7 +47,6 @@
               'calendar-day-number': true,
               'cursor-pointer': calendarDaysAreClickable
             }"
-            @click="handleDayClick(thisDay.dateObject)"
           >
             <quantity-bubble
               :quantity="thisDay.dateObject.day"
@@ -59,7 +59,6 @@
               'calendar-day-number': true,
               'cursor-pointer': calendarDaysAreClickable
             }"
-            @click="handleDayClick(thisDay.dateObject)"
           >
             {{ thisDay.dateObject.day }}
           </div>
@@ -80,6 +79,7 @@
                   :first-day-of-week="(weekDayIndex === 0)"
                   :last-day-of-week="(weekDayIndex === (thisWeek.length -1))"
                   :allow-editing="allowEditing"
+                  @click="handleCalendarEventClick"
                 />
               </div>
             </template>
@@ -145,7 +145,8 @@
         workingDate: new Date(),
         weekArray: [],
         parsed: this.getDefaultParsed(),
-        eventDetailEventObject: {}
+        eventDetailEventObject: {},
+        eventClicked: false
       }
     },
     computed: {
@@ -226,9 +227,18 @@
         this.generateCalendarCellArray()
       },
       handleDayClick: function (dateObject) {
+        // event item clicked; prevent "day" event
+        if (this.eventClicked) {
+          this.eventClicked = false;
+          return;
+        }
         if (this.fullComponentRef) {
           this.fullMoveToDay(dateObject)
         }
+        this.triggerDayClick(dateObject, this.eventRef);
+      },
+      handleCalendarEventClick: function () {
+        this.eventClicked = true;
       }
     },
     mounted () {

--- a/src/components/calendar/mixins/CalendarMixin.js
+++ b/src/components/calendar/mixins/CalendarMixin.js
@@ -30,6 +30,13 @@ export default {
         eventObject
       )
     },
+    triggerDayClick: function (dateObject, eventRef) {
+      this.$root.$emit(
+        'click-day-' + eventRef, {
+          day: dateObject.toObject()
+        }
+      )
+    },
     handleEventDetailEvent: function (params, thisRef) {
       if (!this.preventEventDetail) {
         if (thisRef === undefined) {


### PR DESCRIPTION
Click event now generated on the month's day cell instead of its number
"bubble". A new "click" event handler added to the inserted
`CalendarEvent` instances. When clicked, set new `eventClicked` data
prop to `true`.

If `eventClicked` is `true`, the day event handler will reset it to
`false` and _not_ generate a day click event.

If `eventClicked` is `false`, the day event handler calls new
`CalendarMixin` method `triggerDayClick`.

Added documentation to _readme_ around ability to handle user clicks
on `CalendarMonth` day cells.

---

Closes #45 