### PR TITLE
Replace CloseDialog with ClosePopup directive

### DIFF
--- a/component/calendar/CalendarEventDetail.vue
+++ b/component/calendar/CalendarEventDetail.vue
@@ -76,7 +76,7 @@
           round
           dense
           icon="close"
-          v-close-dialog
+          v-close-popup
         />
       </q-toolbar>
 
@@ -370,7 +370,7 @@
     QIcon,
     QBadge,
     QDialog,
-    CloseDialog,
+    ClosePopup,
     QCard,
     QCardSection,
     QToolbar,
@@ -427,7 +427,7 @@
       FieldTime
     },
     directives: {
-      CloseDialog
+      ClosePopup
     },
     data () {
       return {


### PR DESCRIPTION
Updated _CalendarEventDetail.vue_ component to use quasar's `ClosePopup` directive instead of `CloseDialog`.

---

Closes #60 